### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/go_test_push_docker.yml
+++ b/.github/workflows/go_test_push_docker.yml
@@ -29,7 +29,7 @@ jobs:
 
     - uses: actions/checkout@master
     - name: Publish to Docker Repository
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: meetdocker2020/docker-githubaction-2:v0.0.1
         username: ${{ secrets.DOCKER_USER_NAME }}

--- a/.github/workflows/push_docker.yml.txt
+++ b/.github/workflows/push_docker.yml.txt
@@ -11,7 +11,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Publish to Docker Repository
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: meetdocker2020/docker-githubaction
           username: ${{ secrets.DOCKER_USER_NAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore